### PR TITLE
Offload video processing to another thread

### DIFF
--- a/mazda/main.cpp
+++ b/mazda/main.cpp
@@ -159,7 +159,7 @@ static int gst_pipeline_init(gst_app_t *app)
 	gst_init(NULL, NULL);
 
 	//if we have ASPECT_RATIO_FIX, cut off the bottom black bar
-	const char* vid_pipeline_launch = "appsrc name=mysrc is-live=true block=false max-latency=1000000 do-timestamp=true ! h264parse ! vpudec low-latency=true framedrop=true framedrop-level-mask=0x200 ! mfw_isink name=mysink "
+	const char* vid_pipeline_launch = "appsrc name=mysrc is-live=true block=false max-latency=1000000 do-timestamp=true ! queue ! h264parse ! vpudec low-latency=true framedrop=true framedrop-level-mask=0x200 ! mfw_isink name=mysink "
 	#if ASPECT_RATIO_FIX
     "axis-left=0 axis-top=-20 disp-width=800 disp-height=520"
 	#else

--- a/ubuntu/main.cpp
+++ b/ubuntu/main.cpp
@@ -112,6 +112,7 @@ gst_pipeline_init(gst_app_t *app) {
         gst_init(NULL, NULL);
 
         const char* vid_launch_str = "appsrc name=mysrc is-live=true block=false max-latency=100000 do-timestamp=true stream-type=stream typefind=true ! "
+                "queue ! "
                 "h264parse ! "
                 "avdec_h264 ! "
 #if ASPECT_RATIO_FIX


### PR DESCRIPTION
`queue` command in GST pipelines creates a thread barrier and everything after it is then executed on a separate thread. Adding it to our video pipeline should offload video parsing / decoding to another thread and hopefully helping to fix the audio stutter issues when screen is updated.

Quick test on Ubuntu showed that addin queue halfed the execution time of gst_push_buffer call.