### PR TITLE
Register a Bluetooth service

### DIFF
--- a/hu/hu.proto
+++ b/hu/hu.proto
@@ -251,9 +251,9 @@ message ChannelDescriptor
         enum BluetoothPairingMethod
         {
             BLUETOOTH_PARING_METHOD_1 = 1;
-            BLUETOOTH_PARING_METHOD_2 = 2;
+            BLUETOOTH_PARING_METHOD_A2DP = 2;
             BLUETOOTH_PARING_METHOD_3 = 3;
-            BLUETOOTH_PARING_METHOD_4 = 4;
+            BLUETOOTH_PARING_METHOD_HFP = 4;
         }
         required string car_address = 1;
         repeated BluetoothPairingMethod supported_pairing_methods = 2;

--- a/hu/hu_aap.cpp
+++ b/hu/hu_aap.cpp
@@ -538,8 +538,18 @@
 
     callbacks.CustomizeCarInfo(carInfo);
 
+    HU::ChannelDescriptor* btChannel = carInfo.add_channels();
+    btChannel->set_channel_id(AA_CH_BT);
+    {
+      auto inner = btChannel->mutable_bluetooth_service();
+      callbacks.CustomizeBluetoothService(AA_CH_BT, *inner);
+      inner->add_supported_pairing_methods(HU::ChannelDescriptor_BluetoothService::BLUETOOTH_PARING_METHOD_A2DP);
+      inner->add_supported_pairing_methods(HU::ChannelDescriptor_BluetoothService::BLUETOOTH_PARING_METHOD_HFP);
+    }
+
     return hu_aap_enc_send_message(0, chan, HU_PROTOCOL_MESSAGE::ServiceDiscoveryResponse, carInfo);
   }
+
 
   
   int HUServer::hu_handle_PingRequest (int chan, byte * buf, int len) {                  // Ping Request

--- a/hu/hu_aap.h
+++ b/hu/hu_aap.h
@@ -14,6 +14,7 @@
 #define AA_CH_AU1 5
 #define AA_CH_AU2 6
 #define AA_CH_MIC 7
+#define AA_CH_BT  8
 #define AA_CH_MAX 256
 
 enum HU_STATE
@@ -130,6 +131,7 @@ public:
   virtual void CustomizeSensorConfig(HU::ChannelDescriptor::SensorChannel& sensorChannel) {}
   virtual void CustomizeOutputChannel(int chan, HU::ChannelDescriptor::OutputStreamChannel& streamChannel) {}
   virtual void CustomizeInputChannel(int chan, HU::ChannelDescriptor::InputStreamChannel& streamChannel) {}
+  virtual void CustomizeBluetoothService(int chan, HU::ChannelDescriptor::BluetoothService& bluetoothService) {}
 };
 
 

--- a/mazda/Makefile
+++ b/mazda/Makefile
@@ -31,6 +31,7 @@ SRCS += gps/nematode/src/NMEACommand.cpp
 SRCS += gps/nematode/src/NMEAParser.cpp
 SRCS += gps/nematode/src/NumberConversion.cpp
 SRCS += gps/mzd_gps.cpp
+SRCS += bt/mzd_bluetooth.cpp
 SRCS += main.cpp
 
 OBJS = $(addsuffix .arm.o, $(basename $(SRCS)))

--- a/mazda/bt/mzd_bluetooth.cpp
+++ b/mazda/bt/mzd_bluetooth.cpp
@@ -1,0 +1,78 @@
+#include "mzd_bluetooth.h"
+
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <array>
+#include <iomanip>
+#include <sstream>
+#include <fstream>
+
+// We can retrieve MAC Address from Mazda CMU from two sys paths:
+//    /sys/fsl_otp/HW_OCOTP_MAC1 for the begining
+//    /sys/fsl_otp/HW_OCOTP_MAC0 for the second part
+// The beginning returns first two bytes of MAC, the second part the rest of MAC address as a HEX string.
+// Example:
+// echo /sys/fsl_otp/HW_OCOTP_MAC1 -> 0x88c6
+// echo /sys/fsl_otp/HW_OCOTP_MAC0 -> 0x261b82f2
+// Actual MAC: 88:c6:26:1b:82:f2
+
+// Cache the address if we need to retrieve it repeatedly;
+static std::string macAddress = "";
+
+static uint32_t hexStrToInt(std::string hexStr) {
+    uint32_t x;
+    std::stringstream ss;
+    ss << std::hex << hexStr;
+    ss >> x;
+    return x;
+}
+
+/**
+*   Converts passed number into HEX pair for MAC address, e.g. 10 -> 0A
+*/
+static std::string formatNumber(uint32_t num) {
+    std::stringstream str;
+    if (num < 16) str << "0";   // MACs are padded with zeros... std::setw doesn't woork on HU.
+    str << std::uppercase << std::hex;
+    str << num;
+    std::string out = str.str();
+    return out;
+}
+
+std::string get_bluetooth_mac_address() {
+    if (macAddress != "") return macAddress;
+
+    std::ifstream macUpperFile("/sys/fsl_otp/HW_OCOTP_MAC1");
+    std::ifstream macLowerFile("/sys/fsl_otp/HW_OCOTP_MAC0");
+
+    std::stringstream macUpper;
+    std::stringstream macLower;
+
+    macUpper << macUpperFile.rdbuf();
+    macLower << macLowerFile.rdbuf();
+
+    // Check for I/O error
+    if (macUpperFile.fail() || macLowerFile.fail()) return "";
+
+    uint32_t macAddrUpper = hexStrToInt(macUpper.str());
+    uint32_t macAddrLower = hexStrToInt(macLower.str());
+
+    std::stringstream ss;
+    ss << formatNumber((macAddrUpper >> 8) & 0xFF);
+    ss << ":";
+    ss << formatNumber(macAddrUpper & 0xFF);
+    ss << ":";
+    ss << formatNumber((macAddrLower >> 24) & 0xFF);
+    ss << ":";
+    ss << formatNumber((macAddrLower >> 16) & 0xFF);
+    ss << ":";
+    ss << formatNumber((macAddrLower >> 8) & 0xFF);
+    ss << ":";
+    ss << formatNumber((macAddrLower & 0xFF) + 1);  // Is BT address really always +1 from the base one in file?
+
+    macAddress = ss.str();
+    printf("Bluetooth MAC: %s\n", macAddress.c_str());
+    return macAddress;
+}

--- a/mazda/bt/mzd_bluetooth.h
+++ b/mazda/bt/mzd_bluetooth.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+// This defines a method to retrieve the bluetooth MAC address.
+// The actual implementations are in ubuntu/mazda directories due
+// to the hardware requirements.
+
+std::string get_bluetooth_mac_address();

--- a/mazda/main.cpp
+++ b/mazda/main.cpp
@@ -30,6 +30,7 @@ using json = nlohmann::json;
 
 #include "nm/mzd_nightmode.h"
 #include "gps/mzd_gps.h"
+#include "bt/mzd_bluetooth.h"
 
 #define EVENT_DEVICE_TS	"/dev/input/filtered-touchscreen0"
 #define EVENT_DEVICE_KBD "/dev/input/filtered-keyboard0"
@@ -738,6 +739,10 @@ public:
             videoConfig->set_margin_height(30);
         }
     #endif
+  }
+
+  virtual void CustomizeBluetoothService(int chan, HU::ChannelDescriptor::BluetoothService& bluetoothService) {
+    bluetoothService.set_car_address(get_bluetooth_mac_address());
   }
 };
 

--- a/ubuntu/Makefile
+++ b/ubuntu/Makefile
@@ -13,6 +13,7 @@ SRCS += $(TOP)/hu/hu_usb.cpp
 SRCS += $(TOP)/hu/hu_uti.cpp
 SRCS += $(TOP)/hu/hu_tcp.cpp
 SRCS += $(TOP)/hu/generated.x64/hu.pb.cc
+SRCS += bt/ub_bluetooth.cpp
 SRCS += main.cpp
 
 OBJS = $(addsuffix .x64.o, $(basename $(SRCS)))

--- a/ubuntu/bt/ub_bluetooth.cpp
+++ b/ubuntu/bt/ub_bluetooth.cpp
@@ -1,0 +1,27 @@
+#include "ub_bluetooth.h"
+
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <array>
+
+std::string exec(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) throw std::runtime_error("popen() failed!");
+    while (!feof(pipe.get())) {
+        if (fgets(buffer.data(), 128, pipe.get()) != NULL)
+            result += buffer.data();
+    }
+    return result;
+}
+
+std::string get_bluetooth_mac_address() {
+    const auto output = exec("hcitool dev");
+    // This is naive and simple, but works well for testing.
+    const auto start_of_mac = output.find_last_of('\t');
+    if (start_of_mac == std::string::npos) return "";
+    return output.substr(start_of_mac);
+}

--- a/ubuntu/bt/ub_bluetooth.h
+++ b/ubuntu/bt/ub_bluetooth.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+// This defines a method to retrieve the bluetooth MAC address.
+// The actual implementations are in ubuntu/mazda directories due
+// to the hardware requirements.
+
+std::string get_bluetooth_mac_address();

--- a/ubuntu/main.cpp
+++ b/ubuntu/main.cpp
@@ -16,6 +16,7 @@
 
 #include "hu_uti.h"
 #include "hu_aap.h"
+#include "bt/ub_bluetooth.h"
 
 typedef struct {
         GMainLoop *loop;
@@ -550,6 +551,11 @@ public:
                 }
 #endif
         }
+
+        virtual void
+        CustomizeBluetoothService(int chan, HU::ChannelDescriptor::BluetoothService& bluetoothService) {
+                bluetoothService.set_car_address(get_bluetooth_mac_address());
+        }
 };
 
 int
@@ -573,6 +579,10 @@ main(int argc, char *argv[]) {
         printf("Using hard coded scalefactor\n");
         g_dpi_scalefactor = 1;
 #endif
+
+        std::string bt_mac = get_bluetooth_mac_address();
+        printf("Bluetooth MAC: %s\n", bt_mac.c_str());
+
         gst_app_t *app = &gst_app;
         int ret = 0;
         errno = 0;


### PR DESCRIPTION
This registers a Bluetooth service as channel 8 and reports the HU bluetooth address to the phone. This reenables the dialer interface if the phone is paired and connected to the headunit via BT.

On Ubuntu, the BT address is retrieved with `hcitool`.