### PR TITLE
Increase the size of the USB receive buffer to 16384

### DIFF
--- a/hu/hu_usb.cpp
+++ b/hu/hu_usb.cpp
@@ -560,7 +560,7 @@ int HUTransportStreamUSB::Start(byte ep_in_addr, byte ep_out_addr) {
 
   usb_recv_thread = std::thread([this]{ this->usb_recv_thread_main(); });
 
-  recv_temp_buffer.resize(1024);
+  recv_temp_buffer.resize(16384);
   start_usb_recv();
 
   iusb_state = hu_STATE_STARTED;


### PR DESCRIPTION
With DHU data length is 4096 bytes, with 16384 bytes buffer size the average observed received data length is 8235 bytes and there is no audio tearing.