### PR TITLE
fix for screen corruption with backup camera

### DIFF
--- a/common/glib_utils.cpp
+++ b/common/glib_utils.cpp
@@ -19,9 +19,9 @@ void run_on_main_thread(std::function<bool()>&& f)
     g_source_unref(source);
 }
 
-void run_on_main_thread_delay(guint seconds, std::function<bool()>&& f)
+void run_on_main_thread_delay(guint milliseconds, std::function<bool()>&& f)
 {
-    GSource* source = g_timeout_source_new_seconds(seconds);
+    GSource* source = g_timeout_source_new(milliseconds);
     g_source_set_callback(source, run_on_main_thread_func, new std::function<bool()>(f), nullptr);
 
     g_source_attach(source, run_on_thread_main_context);

--- a/common/glib_utils.h
+++ b/common/glib_utils.h
@@ -6,4 +6,4 @@
 extern GMainContext* run_on_thread_main_context;
 
 void run_on_main_thread(std::function<bool()>&& f);
-void run_on_main_thread_delay(guint seconds, std::function<bool()>&& f);
+void run_on_main_thread_delay(guint milliseconds, std::function<bool()>&& f);

--- a/mazda/callbacks.h
+++ b/mazda/callbacks.h
@@ -15,6 +15,12 @@ class VideoOutput;
 class AudioOutput;
 class MazdaEventCallbacks;
 
+enum VIDEO_FOCUS_REQUESTOR {
+    HEADUNIT, // headunit (we) has requested video focus
+    ANDROID_AUTO, // AA phone app has requested video focus
+    BACKUP_CAMERA // CMU requested screen for backup camera
+};
+
 class AudioManagerClient : public com::xsembedded::ServiceProvider_proxy,
                      public DBus::ObjectProxy
 {
@@ -65,7 +71,7 @@ public:
         virtual void AudioFocusRequest(int chan, const HU::AudioFocusRequest& request) override;
         virtual void VideoFocusRequest(int chan, const HU::VideoFocusRequest& request) override;
 
-        void VideoFocusHappened(bool hasFocus, bool unrequested);
+        void VideoFocusHappened(bool hasFocus, VIDEO_FOCUS_REQUESTOR videoFocusRequestor);
         void AudioFocusHappend(int chan, bool hasFocus);
 
         std::atomic<bool> connected;

--- a/mazda/callbacks.h
+++ b/mazda/callbacks.h
@@ -14,11 +14,48 @@
 class VideoOutput;
 class AudioOutput;
 class MazdaEventCallbacks;
+class VideoManagerClient;
 
-enum VIDEO_FOCUS_REQUESTOR {
-    HEADUNIT, // headunit (we) has requested video focus
-    ANDROID_AUTO, // AA phone app has requested video focus
-    BACKUP_CAMERA // CMU requested screen for backup camera
+class NativeGUICtrlClient : public com::jci::nativeguictrl_proxy,
+                            public DBus::ObjectProxy
+{
+public:
+    NativeGUICtrlClient(DBus::Connection &connection)
+            : DBus::ObjectProxy(connection, "/com/jci/nativeguictrl", "com.jci.nativeguictrl")
+    {
+    }
+
+    enum SURFACES
+    {
+        NNG_NAVI_ID = 0,
+        TV_TOUCH_SURFACE,
+        NATGUI_SURFACE,
+        LOOPLOGO_SURFACE,
+        TRANLOGOEND_SURFACE,
+        TRANLOGO_SURFACE,
+        QUICKTRANLOGO_SURFACE,
+        EXITLOGO_SURFACE,
+        JCI_OPERA_PRIMARY,
+        JCI_OPERA_SECONDARY,
+        lvdsSurface,
+        SCREENREP_IVI_NAME,
+        NNG_NAVI_MAP1,
+        NNG_NAVI_MAP2,
+        NNG_NAVI_HMI,
+        NNG_NAVI_TWN,
+    };
+
+    void SetRequiredSurfacesByEnum(const std::vector<SURFACES>& surfaces, bool fadeOpera)
+    {
+        std::ostringstream idString;
+        for (size_t i = 0; i < surfaces.size(); i++)
+        {
+            if (i > 0)
+                idString << ",";
+            idString << surfaces[i];
+        }
+        SetRequiredSurfaces(idString.str(), fadeOpera ? 1 : 0);
+    }
 };
 
 class AudioManagerClient : public com::xsembedded::ServiceProvider_proxy,
@@ -48,34 +85,64 @@ public:
     virtual void Notify(const std::string& signalName, const std::string& payload) override;
 };
 
-class MazdaEventCallbacks : public IHUConnectionThreadEventCallbacks {
-        std::unique_ptr<VideoOutput> videoOutput;
-        std::unique_ptr<AudioOutput> audioOutput;
+enum class VIDEO_FOCUS_REQUESTOR : u_int8_t {
+    HEADUNIT, // headunit (we) has requested video focus
+    ANDROID_AUTO, // AA phone app has requested video focus
+    BACKUP_CAMERA // CMU requested screen for backup camera
+};
 
-        MicInput micInput;
-        DBus::Connection& serviceBus;
-        DBus::Connection& hmiBus;
+class VideoManagerClient : public com::jci::bucpsa_proxy,
+                           public DBus::ObjectProxy {
+    bool allowedToGetFocus = true;
+    bool waitsForFocus = false;
 
-        std::unique_ptr<AudioManagerClient> audioMgrClient;
+    MazdaEventCallbacks& callbacks;
+    NativeGUICtrlClient guiClient;
 public:
-        MazdaEventCallbacks(DBus::Connection& serviceBus, DBus::Connection& hmiBus);
-        ~MazdaEventCallbacks();
+    VideoManagerClient(MazdaEventCallbacks& callbacks, DBus::Connection &hmiBus);
+    ~VideoManagerClient();
 
-        virtual int MediaPacket(int chan, uint64_t timestamp, const byte * buf, int len) override;
-        virtual int MediaStart(int chan) override;
-        virtual int MediaStop(int chan) override;
-        virtual void MediaSetupComplete(int chan) override;
-        virtual void DisconnectionOrError() override;
-        virtual void CustomizeOutputChannel(int chan, HU::ChannelDescriptor::OutputStreamChannel& streamChannel) override;
-        virtual void AudioFocusRequest(int chan, const HU::AudioFocusRequest& request) override;
-        virtual void VideoFocusRequest(int chan, const HU::VideoFocusRequest& request) override;
+    void requestVideoFocus(VIDEO_FOCUS_REQUESTOR requestor);
+    void releaseVideoFocus(VIDEO_FOCUS_REQUESTOR requestor);
 
-        void VideoFocusHappened(bool hasFocus, VIDEO_FOCUS_REQUESTOR videoFocusRequestor);
-        void AudioFocusHappend(int chan, bool hasFocus);
+    virtual void CommandResponse(const uint32_t& cmdResponse) override {}
+    virtual void DisplayMode(const uint32_t& currentDisplayMode) override;
+    virtual void ReverseStatusChanged(const int32_t& reverseStatus) override {}
+    virtual void PSMInstallStatusChanged(const uint8_t& psmInstalled) override {}
+};
 
-        std::atomic<bool> connected;
-        std::atomic<bool> videoFocus;
-        std::atomic<bool> audioFocus;
+class MazdaEventCallbacks : public IHUConnectionThreadEventCallbacks {
+    std::unique_ptr<VideoOutput> videoOutput;
+    std::unique_ptr<AudioOutput> audioOutput;
+
+    MicInput micInput;
+    DBus::Connection& serviceBus;
+    DBus::Connection& hmiBus;
+
+    std::unique_ptr<AudioManagerClient> audioMgrClient;
+    std::unique_ptr<VideoManagerClient> videoMgrClient;
+public:
+    MazdaEventCallbacks(DBus::Connection& serviceBus, DBus::Connection& hmiBus);
+    ~MazdaEventCallbacks();
+
+    virtual int MediaPacket(int chan, uint64_t timestamp, const byte * buf, int len) override;
+    virtual int MediaStart(int chan) override;
+    virtual int MediaStop(int chan) override;
+    virtual void MediaSetupComplete(int chan) override;
+    virtual void DisconnectionOrError() override;
+    virtual void CustomizeOutputChannel(int chan, HU::ChannelDescriptor::OutputStreamChannel& streamChannel) override;
+    virtual void AudioFocusRequest(int chan, const HU::AudioFocusRequest& request) override;
+    virtual void VideoFocusRequest(int chan, const HU::VideoFocusRequest& request) override;
+
+    void takeVideoFocus();
+    void releaseVideoFocus();
+
+    void VideoFocusHappened(bool hasFocus, bool unrequested);
+    void AudioFocusHappend(int chan, bool hasFocus);
+
+    std::atomic<bool> connected;
+    std::atomic<bool> videoFocus;
+    std::atomic<bool> audioFocus;
 };
 
 class MazdaCommandServerCallbacks : public ICommandServerCallbacks

--- a/mazda/outputs.cpp
+++ b/mazda/outputs.cpp
@@ -270,7 +270,7 @@ void VideoOutput::input_thread_func()
                         if (isPressed)
                         {
                             //go back to home screen
-                            callbacks->VideoFocusHappened(false, true);
+                            callbacks->VideoFocusHappened(false, VIDEO_FOCUS_REQUESTOR::HEADUNIT);
                         }
                         break;
                     case KEY_R:
@@ -373,17 +373,10 @@ VideoOutput::VideoOutput(MazdaEventCallbacks* callbacks, DBus::Connection& hmiBu
     gst_app_src_set_stream_type(vid_src, GST_APP_STREAM_TYPE_STREAM);
 
     gst_element_set_state((GstElement*)vid_pipeline, GST_STATE_PLAYING);
-
-    NativeGUICtrlClient guiClient(hmiBus);
-    //By setting these manually we can run even when not launched by the JS code
-    guiClient.SetRequiredSurfacesByEnum({NativeGUICtrlClient::TV_TOUCH_SURFACE}, true);
 }
 
 VideoOutput::~VideoOutput()
 {
-    NativeGUICtrlClient guiClient(hmiBus);
-    guiClient.SetRequiredSurfacesByEnum({NativeGUICtrlClient::JCI_OPERA_PRIMARY}, true);
-
     gst_element_set_state((GstElement*)vid_pipeline, GST_STATE_NULL);
 
     //data we write doesn't matter, wake up touch polling thread
@@ -416,13 +409,6 @@ void VideoOutput::MediaPacket(uint64_t timestamp, const byte *buf, int len)
 void BUCPSAClient::DisplayMode(const uint32_t &currentDisplayMode)
 {
     logw("Got DisplayMode: %u\n", currentDisplayMode);
-    if (currentDisplayMode)
-    {
-        callbacks->VideoFocusHappened(true, true);
-    }
-    else
-    {
-        callbacks->VideoFocusHappened(false, true);
-    }
+    callbacks->VideoFocusHappened(!(bool)currentDisplayMode, VIDEO_FOCUS_REQUESTOR::BACKUP_CAMERA);
 }
 

--- a/mazda/outputs.cpp
+++ b/mazda/outputs.cpp
@@ -239,23 +239,9 @@ void VideoOutput::input_thread_func()
                         printf("KEY_LEFT\n");
                         scanCode = HUIB_LEFT;
                         break;
-                    case KEY_N:
-                        printf("KEY_N\n");
-                        if (isPressed)
-                        {
-                            scrollAmount = -1;
-                        }
-                        break;
                     case KEY_RIGHT:
                         printf("KEY_RIGHT\n");
                         scanCode = HUIB_RIGHT;
-                        break;
-                    case KEY_M:
-                        printf("KEY_M\n");
-                        if (isPressed)
-                        {
-                            scrollAmount = 1;
-                        }
                         break;
                     case KEY_UP:
                         printf("KEY_UP\n");
@@ -265,12 +251,23 @@ void VideoOutput::input_thread_func()
                         printf("KEY_DOWN\n");
                         scanCode = HUIB_DOWN;
                         break;
+                    case KEY_N:
+                        printf("KEY_N\n");
+                        if (isPressed) {
+                            scrollAmount = -1;
+                        }
+                        break;
+                    case KEY_M:
+                        printf("KEY_M\n");
+                        if (isPressed) {
+                            scrollAmount = 1;
+                        }
+                        break;
                     case KEY_HOME:
                         printf("KEY_HOME\n");
-                        if (isPressed)
-                        {
+                        if (isPressed) {
                             //go back to home screen
-                            callbacks->VideoFocusHappened(false, VIDEO_FOCUS_REQUESTOR::HEADUNIT);
+                            callbacks->releaseVideoFocus();
                         }
                         break;
                     case KEY_R:
@@ -309,10 +306,8 @@ void VideoOutput::input_thread_func()
 
 
 
-VideoOutput::VideoOutput(MazdaEventCallbacks* callbacks, DBus::Connection& hmiBus)
-    : hmiBus(hmiBus)
-    , callbacks(callbacks)
-    , displayClient(hmiBus, callbacks)
+VideoOutput::VideoOutput(MazdaEventCallbacks* callbacks)
+    : callbacks(callbacks)
 {
     /* Open Touchscreen Device */
     touch_fd = open(EVENT_DEVICE_TS, O_RDONLY);
@@ -405,10 +400,3 @@ void VideoOutput::MediaPacket(uint64_t timestamp, const byte *buf, int len)
         printf("push buffer returned %d for %d bytes \n", ret, len);
     }
 }
-
-void BUCPSAClient::DisplayMode(const uint32_t &currentDisplayMode)
-{
-    logw("Got DisplayMode: %u\n", currentDisplayMode);
-    callbacks->VideoFocusHappened(!(bool)currentDisplayMode, VIDEO_FOCUS_REQUESTOR::BACKUP_CAMERA);
-}
-

--- a/mazda/outputs.h
+++ b/mazda/outputs.h
@@ -23,68 +23,6 @@
 struct gst_app_t;
 class MazdaEventCallbacks;
 
-class BUCPSAClient : public com::jci::bucpsa_proxy,
-                     public DBus::ObjectProxy
-{
-    MazdaEventCallbacks* callbacks;
-public:
-    BUCPSAClient(DBus::Connection &connection, MazdaEventCallbacks* callbacks)
-        : DBus::ObjectProxy(connection, "/com/jci/bucpsa", "com.jci.bucpsa"),
-          callbacks(callbacks)
-    {
-    }
-
-    virtual void CommandResponse(const uint32_t& cmdResponse) override {}
-    virtual void DisplayMode(const uint32_t& currentDisplayMode) override;
-    virtual void ReverseStatusChanged(const int32_t& reverseStatus) override {}
-    virtual void PSMInstallStatusChanged(const uint8_t& psmInstalled) override {}
-};
-
-
-class NativeGUICtrlClient : public com::jci::nativeguictrl_proxy,
-                     public DBus::ObjectProxy
-{
-public:
-    NativeGUICtrlClient(DBus::Connection &connection)
-        : DBus::ObjectProxy(connection, "/com/jci/nativeguictrl", "com.jci.nativeguictrl")
-    {
-    }
-
-    enum SURFACES
-    {
-        NNG_NAVI_ID = 0,
-        TV_TOUCH_SURFACE,
-        NATGUI_SURFACE,
-        LOOPLOGO_SURFACE,
-        TRANLOGOEND_SURFACE,
-        TRANLOGO_SURFACE,
-        QUICKTRANLOGO_SURFACE,
-        EXITLOGO_SURFACE,
-        JCI_OPERA_PRIMARY,
-        JCI_OPERA_SECONDARY,
-        lvdsSurface,
-        SCREENREP_IVI_NAME,
-        NNG_NAVI_MAP1,
-        NNG_NAVI_MAP2,
-        NNG_NAVI_HMI,
-        NNG_NAVI_TWN,
-    };
-
-    void SetRequiredSurfacesByEnum(const std::vector<SURFACES>& surfaces, bool fadeOpera)
-    {
-        std::ostringstream idString;
-        for (size_t i = 0; i < surfaces.size(); i++)
-        {
-            if (i > 0)
-                idString << ",";
-            idString << surfaces[i];
-        }
-        SetRequiredSurfaces(idString.str(), fadeOpera ? 1 : 0);
-    }
-};
-
-class MazdaEventCallbacks;
-
 class VideoOutput {
     GstElement *vid_pipeline = nullptr;
     GstAppSrc *vid_src = nullptr;
@@ -97,10 +35,8 @@ class VideoOutput {
     int touch_fd = -1, kbd_fd = -1;
     void input_thread_func();
 
-    DBus::Connection& hmiBus;
-    BUCPSAClient displayClient;
 public:
-    VideoOutput(MazdaEventCallbacks* callbacks, DBus::Connection& hmiBus);
+    VideoOutput(MazdaEventCallbacks* callbacks);
     ~VideoOutput();
 
     void MediaPacket(uint64_t timestamp, const byte * buf, int len);

--- a/ubuntu/callbacks.h
+++ b/ubuntu/callbacks.h
@@ -11,6 +11,10 @@
 class VideoOutput;
 class AudioOutput;
 
+enum VIDEO_FOCUS_REQUESTOR {
+    HEADUNIT, // headunit (we) has requested video focus
+    ANDROID_AUTO // AA phone app has requested video focus
+};
 
 class DesktopEventCallbacks : public IHUConnectionThreadEventCallbacks {
         std::unique_ptr<VideoOutput> videoOutput;
@@ -30,7 +34,7 @@ public:
         virtual void AudioFocusRequest(int chan, const HU::AudioFocusRequest& request) override;
         virtual void VideoFocusRequest(int chan, const HU::VideoFocusRequest& request) override;
 
-        void VideoFocusHappened(bool hasFocus, bool unrequested);
+        void VideoFocusHappened(bool hasFocus, VIDEO_FOCUS_REQUESTOR videoFocusRequestor);
 
         std::atomic<bool> connected;
         std::atomic<bool> videoFocus;

--- a/ubuntu/outputs.cpp
+++ b/ubuntu/outputs.cpp
@@ -235,7 +235,7 @@ gboolean VideoOutput::sdl_poll_event() {
         case SDL_QUIT:
             {
                 //we "lost video focus"
-                callbacks->VideoFocusHappened(false, true);
+                callbacks->VideoFocusHappened(false, VIDEO_FOCUS_REQUESTOR::HEADUNIT);
             }
             break;
         }


### PR DESCRIPTION
Fixes #48. As AA and backup camera share the same TV_TOUCH_SURFACE we need to stop video output and leave the surface when backup camera kicks in.