### PR TITLE
Enhancements applied to the new installer

### DIFF
--- a/mazda/installer/tweaks.sh
+++ b/mazda/installer/tweaks.sh
@@ -314,8 +314,10 @@ else
     # this is an update path - installed=true, remove=false
     show_message "UPDATING" "Android Auto is updating ..."
 
-    #still modify cmu_files incase they were updated
+    # still modify cmu_files in case they were updated
     modify_cmu_files
+    # remove all files and copy once again in case there were some orphaned files in CMU
+    remove_aa_binaries
     copy_aa_binaries
     test_run
 

--- a/mazda/installer/tweaks.sh
+++ b/mazda/installer/tweaks.sh
@@ -21,7 +21,7 @@ if [ -f "${MYDIR}/installer_log.txt" ]; then
     #save old logs
     logidx=1
     while [ -f "${MYDIR}/installer_log_${logidx}.txt" ]; do
-        let logidx=logidx+1
+        logidx=$(($logidx+1))
     done
     mv "${MYDIR}/installer_log.txt" "${MYDIR}/installer_log_${logidx}.txt"
 fi
@@ -252,6 +252,14 @@ log_message "Installer started.\n"
 
 log_message "MYDIR = ${MYDIR}\n"
 log_message "CMU version = ${CMU_SW_VER}\n"
+
+# check software version first
+echo ${CMU_SW_VER} | /bin/sed "/^5[69]\..*/Q 1"
+if [ $? -ne 1 ]; then
+    log_message "Script aborted due to CMU version mismatch."
+    show_message "Aborted" "This version of CMU is not supported. Please update first."
+    exit
+fi
 
 # first test, if copy from MZD to sd card is working to test correct mount point
 log_message "Check mount point ... "


### PR DESCRIPTION
This commit adds simple CMU version compatibility checking to prevent installation on older firmware that could end with a bootloop. Additionally it may be desired to remove old files on update to be sure no orphaned (not used) files are left in the system.