### PR TITLE
Fix Possible Security Bugs

### DIFF
--- a/hu/hu_aad.cpp
+++ b/hu/hu_aad.cpp
@@ -191,7 +191,7 @@ Channel specified for each service:
       //snprintf (str_buf, sizeof (str_buf), "%1.1d", num);
       int ctr = 0;
       for (ctr = 0; ctr < n - 1; ctr ++)
-        strncat (str_buf, "                    ", sizeof (str_buf));
+        strncat (str_buf, "                    ", sizeof(str_buf) - strlen(str_buf) - 1);
 
 
       //unsigned char str_buf2 [256] = {0};
@@ -237,10 +237,10 @@ Channel specified for each service:
       char str_buf [256] = {0};
       int ctr = 0;
       for (ctr = 0; ctr < n - 1; ctr ++)
-        strncat (str_buf, "                    ", sizeof (str_buf));
+        strncat (str_buf, "                    ", sizeof(str_buf) - strlen(str_buf) - 1);
 
       char str_buf2 [256] = {0};
-      snprintf (str_buf2, sizeof (str_buf), "%s%1.1d", str_buf, num);   // Dump raw array
+      snprintf (str_buf2, sizeof (str_buf), "%s%1.1u", str_buf, num);   // Dump raw array
       hex_dump (str_buf2, 16, buf, alen);
     }
 

--- a/hu/hu_tcp.cpp
+++ b/hu/hu_tcp.cpp
@@ -86,7 +86,7 @@
     if (tcp_so_fd < 0)
       return (-1);
 
-    memset ((char *) & cli_addr, sizeof (cli_addr), 0);                 // ?? Don't need this ?
+    memset ((char *) & cli_addr, 0, sizeof (cli_addr));                 // ?? Don't need this ?
     //cli_addr.sun_family = CS_FAM;                                     // ""
     cli_len = sizeof (cli_addr);
 
@@ -138,7 +138,7 @@
       logd ("setsockopt TCP_NODELAY Success");
 
     if (wifi_direct) {
-        memset ((char *) & srv_addr, sizeof (srv_addr), 0);
+        memset ((char *) & srv_addr, 0, sizeof (srv_addr));
 
         srv_addr.sin_family = AF_INET;
         srv_addr.sin_addr.s_addr = htonl (INADDR_ANY);                      // Will bind to any/all Interfaces/IPs

--- a/hu/hu_uti.cpp
+++ b/hu/hu_uti.cpp
@@ -94,13 +94,18 @@ int hu_log (int prio, const char * tag, const char * func, const char * fmt, ...
   snprintf (tag_str, sizeof (tag_str), "%32.32s", func);
   __android_log_vprint (prio, tag_str, fmt, ap);
 #else
-  char log_line [4096] = {0};
   va_list aq;
-  va_start (aq, fmt); 
+  va_start (aq, fmt);
+
+  char log_line [4096] = {0};
   int len = vsnprintf (log_line, sizeof (log_line), fmt, aq);
+
   //Time doesn't work on CMU anyway, always says 1970
   printf ("%s: %s: %s : %s\n", prio_get (prio), tag, func, log_line);
+
+  va_end(aq);
 #endif
+  va_end(ap);
 
   // if (prio == hu_LOG_ERR)
   // {
@@ -139,15 +144,15 @@ void hex_dump (const char * prefix, int width, unsigned char * buf, int len) {
 
   if (prefix)
     //strlcpy (line, prefix, sizeof (line));
-    strlcat (line, prefix, sizeof (line));
+    strlcat (line, prefix, sizeof(line));
 
   snprintf (tmp, sizeof (tmp), " %8.8x ", 0);
-  strlcat (line, tmp, sizeof (line));
+  strlcat (line, tmp, sizeof(line) - strlen(line));
 
   for (i = 0, n = 1; i < len; i ++, n ++) {                           // i keeps incrementing, n gets reset to 0 each line
 
     snprintf (tmp, sizeof (tmp), "%2.2x ", buf [i]);
-    strlcat (line, tmp, sizeof (line));                               // Append 2 bytes hex and space to line
+    strlcat (line, tmp, sizeof(line) - strlen(line));                 // Append 2 bytes hex and space to line
 
     if (n == width) {                                                 // If at specified line width
       n = 0;                                                          // Reset position in line counter
@@ -156,11 +161,11 @@ void hex_dump (const char * prefix, int width, unsigned char * buf, int len) {
       line [0] = 0;
       if (prefix)
         //strlcpy (line, prefix, sizeof (line));
-        strlcat (line, prefix, sizeof (line));
+        strlcat (line, prefix, sizeof(line) - strlen(line));
 
       //snprintf (tmp, sizeof (tmp), " %8.8x ", i + 1);
       snprintf (tmp, sizeof (tmp), "     %4.4x ", i + 1);
-      strlcat (line, tmp, sizeof (line));
+      strlcat (line, tmp, sizeof(line) - strlen(line));
     }
     else if (i == len - 1)                                            // Else if at last byte
       logd (line);                                                    // Log line


### PR DESCRIPTION
The code makes use of `strncat` and `strlcat`, but neglects to provide the correct available size of the string buffer.

`strncat`:
The third parameter (maximum number of characters to be appended) has to take the current length of the string into account (especially in the case of concatenation in a loop) AND the terminating \0.
Therefore the size to copy should be: `sizeof(STRING_BUFFER) - strlen(STRING_BUFFER) - 1` .

`strlcat`:
The third parameter has to take the current length of the string into account BUT NOT the terminating \0.
Therefore the size to copy should be: `sizeof(STRING_BUFFER) - strlen(STRING_BUFFER)`