### PR TITLE
Hook surface functions to intercept focus change

### DIFF
--- a/mazda/installer/config/androidauto/jci/gui/apps/_androidauto/js/preload.js
+++ b/mazda/installer/config/androidauto/jci/gui/apps/_androidauto/js/preload.js
@@ -1,0 +1,69 @@
+
+function AAInstallHook()
+{
+    if (this.hookInstalled == true)
+        return;
+
+    var showOperaSurface_orig = framework.showOperaSurface.bind(framework);
+    var showTemplateSurfaces_orig = framework._showTemplateSurfaces.bind(framework);
+    var hideTemplateSurfaces_orig = framework._hideTemplateSurfaces.bind(framework);
+    var hasAAVideoFocus = function()
+    {
+        var ret = false;
+        try
+        {
+            var currentStatus = null;
+            var xhttp = new XMLHttpRequest();
+            xhttp.onreadystatechange = function()
+            {
+                if (xhttp.readyState == 4)
+                {
+                    if (xhttp.status == 200)
+                    {
+                        currentStatus = JSON.parse(xhttp.responseText);
+                    }
+                }
+            };
+            xhttp.open("GET", "http://localhost:9999/status", false);
+            xhttp.send();
+            if (currentStatus != null && currentStatus.videoFocus && currentStatus.connected)
+            {
+                ret = true;
+            }
+        }
+        catch(err)
+        {
+            //do nothing
+        }
+        return ret;
+    };
+
+    framework.showOperaSurface = function()
+    {
+        if (!hasAAVideoFocus())
+        {
+            showOperaSurface_orig();
+        }
+    }
+
+    framework._showTemplateSurfaces = function(someTemplate)
+    {
+        if (!hasAAVideoFocus())
+        {
+            showTemplateSurfaces_orig(someTemplate);
+        }
+    }
+
+    framework._hideTemplateSurfaces = function(someTemplate)
+    {
+        if (!hasAAVideoFocus())
+        {
+            return hideTemplateSurfaces_orig(someTemplate);
+        }
+        return false;
+    }
+
+    this.hookInstalled = true;
+}
+
+AAInstallHook();

--- a/mazda/installer/config/androidauto/jci/opera/opera_dir/userjs/additionalApps.js
+++ b/mazda/installer/config/androidauto/jci/opera/opera_dir/userjs/additionalApps.js
@@ -27,6 +27,10 @@ function addAdditionalApps() {
 				systemApp._masterApplicationDataList.items.push({ appData : { appName : additionalApp.name, isVisible : true,  mmuiEvent : 'Select'+additionalApp.name }, text1Id : additionalApp.name, disabled : false, itemStyle : 'style01', hasCaret : false });
 				framework.localize._appDicts[systemAppId][additionalApp.name] = additionalApp.label;
 				framework.common._contextCategory._contextCategoryTable[additionalApp.name+'.*'] = category;
+				if (additionalApp.preload != null) {
+					var preloadPath = "apps/" + additionalApp.name + "/js/" + additionalApp.preload;
+					utility.loadScript(preloadPath);
+				}
 			}
 
 			// intercept app selection from the list to do our magic

--- a/mazda/installer/config/androidauto/jci/opera/opera_dir/userjs/additionalApps.json
+++ b/mazda/installer/config/androidauto/jci/opera/opera_dir/userjs/additionalApps.json
@@ -1,3 +1,3 @@
 [
-	{ "name": "_androidauto", "label": "Android Auto" }
+	{ "name": "_androidauto", "label": "Android Auto", "preload": "preload.js" }
 ]


### PR DESCRIPTION
This hooks the showOperaSurface  and _showTemplateSurfaces/_hideTemplateSurfaces  functions on the GuiFramework to disable them when AA has video focus. This prevents the phone call from stealing focus since luckily it goes through the JS API via the JS phone app

I had to add some functionality to additionalApps.js to set this up since otherwise the app JS is only loaded when you first open the app. @Trevelopment I assume you are really familiar with this code and possibly the author so can you take a look to make sure there are no weird side effects to how I did this?