### PR TITLE
Scroll aaStatusText box with multicontroller

### DIFF
--- a/mazda/installer/config/androidauto/jci/gui/apps/_androidauto/templates/AndroidAuto/js/AndroidAutoTmplt.js
+++ b/mazda/installer/config/androidauto/jci/gui/apps/_androidauto/templates/AndroidAuto/js/AndroidAutoTmplt.js
@@ -23,6 +23,17 @@ function AndroidAutoTmplt(uiaId, parentDiv, templateID, controlProperties)
 AndroidAutoTmplt.prototype.handleControllerEvent = function(eventID)
 {
     log.debug('handleController() called, eventID: ' + eventID);
+	switch(eventID) {
+		
+		case "ccw":
+		case "up":
+			document.getElementById("aaStatusText").scrollTop -= 100;
+			break;
+		case "cw":
+		case "down":
+			document.getElementById("aaStatusText").scrollTop += 100;
+			break;
+	}
     return 'giveFocusLeft';
 };
 


### PR DESCRIPTION
The tiny scroll bars in Opera Mini are so annoying and it doesn't support the css psudo-element ::-webkit-scrollbar so with this PR you can scroll the textbox with the command knob.