### PR TITLE
Audio-channel-default + Remove vehicle GPS

### DIFF
--- a/mazda/callbacks.cpp
+++ b/mazda/callbacks.cpp
@@ -17,7 +17,7 @@ MazdaEventCallbacks::MazdaEventCallbacks(DBus::Connection& serviceBus, DBus::Con
     , audioFocus(false)
 {
     //no need to create/destroy this
-    audioOutput.reset(new AudioOutput("entertainmentUsb", true));
+    audioOutput.reset(new AudioOutput("entertainmentUsb", false));
     audioMgrClient.reset(new AudioManagerClient(*this, serviceBus));
     videoMgrClient.reset(new VideoManagerClient(*this, hmiBus));
 }


### PR DESCRIPTION
### These 2 very small changes make a huge difference in sound and performance.  Give it a test run and you will notice the difference.
- The audio stream channel is kind of a personal preference but the general consensus seems to be that it is better when set to "default" and I agree with that.  Also, some were reporting that the "entertainmentUsb" channel was too quiet so when they switched back to radio, it would be at a blasting high volume. I actually was meaning to make this issue #93 as a joke since the day after you changed it @lmagder 🔧 fix #93 😁 
- I didn't know that AA was processing the vehicle GPS and the phone GPS together but someone found that removing the vehicle GPS does not seem to effect the navigation at all, in fact in my testing I think it was working a little better even.   It definitely greatly reduces audio stuttering when using maps, while I was driving the freeway I zoomed all the way out to space then fast to the ground to where I'm just a little car zipping across the screen without any lag or stuttering.  After doing that a few times I started to get a little but it took me trying to get it to happen.  Before it would happen pretty much every time you would zoom at all so this possibly fixes #51, fixes #61, & fixes #87...  plus this quite possibly may fix something I thought was unfixable, the people who are having issues with the HUD reading and other navigation related issues like #11.   On top of all that I noticed that I didn't get stuck with the 'black screen' as much when exiting and reentering AA and just an overall performance improvement.. 
 @lmagder is there a reason why  it is necessary to use the vehicle GPS?  Because not using it gives AA a very significant performance boost.