### PR TITLE
Use unused MLENT stream

### DIFF
--- a/mazda/callbacks.cpp
+++ b/mazda/callbacks.cpp
@@ -17,7 +17,7 @@ MazdaEventCallbacks::MazdaEventCallbacks(DBus::Connection& serviceBus, DBus::Con
     , audioFocus(AudioManagerClient::FocusType::NONE)
 {
     //no need to create/destroy this
-    audioOutput.reset(new AudioOutput("entertainmentUsb"));
+    audioOutput.reset(new AudioOutput("entertainmentMl"));
     audioMgrClient.reset(new AudioManagerClient(*this, serviceBus));
     videoMgrClient.reset(new VideoManagerClient(*this, hmiBus));
 }
@@ -375,6 +375,14 @@ void AudioManagerClient::populateStreamTable()
             if(streamName == aaStreamName)
             {
                 aaSessionID = sessionId;
+            }
+            else if(streamName == "USB")
+            {
+                usbSessionID = sessionId;
+            }
+            else if(streamName == "FM")
+            {
+                fmSessionID = sessionId;
             }
         }
         // Create and register stream (only if we need to)

--- a/mazda/callbacks.h
+++ b/mazda/callbacks.h
@@ -70,8 +70,10 @@ public:
     };
 private:
     std::map<std::string, int> streamToSessionIds;
-    std::string aaStreamName = "USB";
+    std::string aaStreamName = "MLENT";
     int aaSessionID = -1;
+    int usbSessionID = -1;
+    int fmSessionID = -1;
     int previousSessionID = -1;
     bool aaStreamRegistered = false;
     bool waitingForFocusLostEvent = false;


### PR DESCRIPTION
I have done it!!! I looked through all the sound configuration file and I noticed an unused stream that was fully set up with its own alsa device, MLENT.  By using that stream, AA is now on its own stream and it solves most of the sound focus issues (or at least makes them easier to fix)