### PR TITLE
Modified GPS Routines to make it stable from a /dev/ttyxxx to a dbus read

### DIFF
--- a/mazda/gps/mzd_gps.h
+++ b/mazda/gps/mzd_gps.h
@@ -1,12 +1,10 @@
-#pragma once
 
-#include <cstdint>
-#include <functional>
+#define GPS_NO_VALUE -1
+#define GPS_OK 0
 
-/** Starts GPS data collection thread. It'll read the serial port and call the callback on
-    started thread with read location.
-    Callback parameters: epoch timestamp, latitude, longitude, bearing, speed, altitude, accuracy **/
-void mzd_gps_start(void(*callbackPtr)(uint64_t, double, double, double, double, double, double));
+void mzd_gps2_start();
 
-/** Stop the GPS collection thread. **/
-void mzd_gps_stop();
+int mzd_gps2_get(int32_t& p1, uint64_t& p2, double& p3, double& p4, int32_t& p5, double& p6, double& p7, double& p8, double& p9);
+
+void mzd_gps2_stop();
+


### PR DESCRIPTION
This modification allows retrieval of GPS data from dbus instead of /dev/ttymxc2.  There is an existing process which takes full control of GPS port /dev/ttymxc2 upon bootup and reads NMEA data, and extracts the necessary GPS data and pushes it to the dbus facility.  With the dbus approach multiple applications can share data from the GPS avoiding any data corruption.