### PR TITLE
Add AA to _applicationsCtxtWiseAppNames for v59+

### DIFF
--- a/mazda/installer/config/androidauto/jci/opera/opera_dir/userjs/additionalApps.js
+++ b/mazda/installer/config/androidauto/jci/opera/opera_dir/userjs/additionalApps.js
@@ -27,7 +27,10 @@ function addAdditionalApps() {
 				systemApp._masterApplicationDataList.items.push({ appData : { appName : additionalApp.name, isVisible : true,  mmuiEvent : 'Select'+additionalApp.name }, text1Id : additionalApp.name, disabled : false, itemStyle : 'style01', hasCaret : false });
 				framework.localize._appDicts[systemAppId][additionalApp.name] = additionalApp.label;
 				framework.common._contextCategory._contextCategoryTable[additionalApp.name+'.*'] = category;
-				if (additionalApp.preload != null) {
+				if(typeof systemApp._applicationsCtxtWiseAppNames !== "undefined" && systemApp._applicationsCtxtWiseAppNames.Applications.indexOf(additionalApp.name) === -1) {
+					systemApp._applicationsCtxtWiseAppNames.Applications.push(additionalApp.name);
+				}
+				if (additionalApp.preload !== undefined) {
 					var preloadPath = "apps/" + additionalApp.name + "/js/" + additionalApp.preload;
 					utility.loadScript(preloadPath);
 				}


### PR DESCRIPTION
In v59 there is an additional array that is checked when populating the app list.  Before this was solved by patching systemApp.js but this solves the issue without the need for a patch.