### PR TITLE
Detect the phone IP address and write it to the config file, where the headunit program will read it and attempt to connect.

### DIFF
--- a/common/config.cpp
+++ b/common/config.cpp
@@ -7,6 +7,7 @@ std::string config::configFile = "/tmp/root/headunit.json";
 bool config::launchOnDevice = true;
 bool config::carGPS = true;
 HU_TRANSPORT_TYPE config::transport_type = HU_TRANSPORT_TYPE::USB;
+std::string config::phoneIpAddress = "192.168.43.1";
 bool config::reverseGPS = false;
 
 void config::parseJson(json config_json)
@@ -22,6 +23,10 @@ void config::parseJson(json config_json)
     if (config_json["wifiTransport"].is_boolean())
     {
         config::transport_type = config_json["wifiTransport"] ? HU_TRANSPORT_TYPE::WIFI : HU_TRANSPORT_TYPE::USB;
+    }
+    if (config_json["phoneIpAddress"].is_string())
+    {
+        config::phoneIpAddress = config_json["phoneIpAddress"];
     }
     if (config_json["reverseGPS"].is_boolean())
     {

--- a/common/config.h
+++ b/common/config.h
@@ -14,6 +14,7 @@ public:
     static bool launchOnDevice;
     static bool carGPS;
     static HU_TRANSPORT_TYPE transport_type;
+    static std::string phoneIpAddress;
     static bool reverseGPS;
 
 private:

--- a/hu/hu_aap.cpp
+++ b/hu/hu_aap.cpp
@@ -34,10 +34,10 @@
 
   }
 
-  int HUServer::ihu_tra_start (HU_TRANSPORT_TYPE transportType, bool waitForDevice) {
+  int HUServer::ihu_tra_start (HU_TRANSPORT_TYPE transportType, std::string& phoneIpAddress, bool waitForDevice) {
     if (transportType == HU_TRANSPORT_TYPE::WIFI) {
       logd ("AA over Wifi");
-      transport = std::unique_ptr<HUTransportStream>(new HUTransportStreamTCP());
+      transport = std::unique_ptr<HUTransportStream>(new HUTransportStreamTCP(phoneIpAddress));
       iaap_tra_recv_tmo = 1000;
       iaap_tra_send_tmo = 2000;
     }
@@ -1310,7 +1310,7 @@
 
   static_assert(PIPE_BUF >= sizeof(IHUAnyThreadInterface::HUThreadCommand*), "PIPE_BUF is tool small for a pointer?");
 
-  int HUServer::hu_aap_start (HU_TRANSPORT_TYPE transportType, bool waitForDevice) {                // Starts Transport/USBACC/OAP, then AA protocol w/ VersReq(1), SSL handshake, Auth Complete
+  int HUServer::hu_aap_start (HU_TRANSPORT_TYPE transportType, std::string& phoneIpAddress, bool waitForDevice) {                // Starts Transport/USBACC/OAP, then AA protocol w/ VersReq(1), SSL handshake, Auth Complete
 
     if (iaap_state == hu_STATE_STARTED || iaap_state == hu_STATE_STARTIN) {
       loge ("CHECK: iaap_state: %d (%s)", iaap_state, state_get (iaap_state));
@@ -1322,7 +1322,7 @@
     iaap_state = hu_STATE_STARTIN;
     logd ("  SET: iaap_state: %d (%s)", iaap_state, state_get (iaap_state));
 
-    int ret = ihu_tra_start (transportType, waitForDevice);                   // Start Transport/USBACC/OAP
+    int ret = ihu_tra_start (transportType, phoneIpAddress, waitForDevice);                   // Start Transport/USBACC/OAP
     if (ret) {
       iaap_state = hu_STATE_STOPPED;
       logd ("  SET: iaap_state: %d (%s)", iaap_state, state_get (iaap_state));

--- a/hu/hu_aap.h
+++ b/hu/hu_aap.h
@@ -187,7 +187,7 @@ class HUServer : protected IHUConnectionThreadInterface
 {
 public:
   //Must be called from the "main" thread (as defined by the user)
-  int hu_aap_start    (HU_TRANSPORT_TYPE transportType, bool waitForDevice);
+  int hu_aap_start    (HU_TRANSPORT_TYPE transportType, std::string& phoneIpAddress, bool waitForDevice);
   int hu_aap_shutdown ();
 
   HUServer(IHUConnectionThreadEventCallbacks& callbacks);
@@ -227,7 +227,7 @@ protected:
   int hu_ssl_begin_handshake ();
   int hu_handle_SSLHandshake(int chan, byte * buf, int len);
 
-  int ihu_tra_start (HU_TRANSPORT_TYPE transportType, bool waitForDevice);
+  int ihu_tra_start (HU_TRANSPORT_TYPE transportType, std::string& phoneIpAddress, bool waitForDevice);
   int ihu_tra_stop();
   int iaap_msg_process (int chan, uint16_t msg_type, byte * buf, int len);
 

--- a/hu/hu_tcp.cpp
+++ b/hu/hu_tcp.cpp
@@ -98,7 +98,7 @@
       }
     }
     else {
-      cli_addr.sin_addr.s_addr = inet_addr("192.168.43.1");
+      cli_addr.sin_addr.s_addr = inet_addr(phoneIpAddress.c_str());
       cli_addr.sin_family = AF_INET;
       cli_addr.sin_port = htons (5277);
       //logd ("cli_len: %d  fam: %d  addr: 0x%x  port: %d",cli_len,cli_addr.sin_family, ntohl (cli_addr.sin_addr.s_addr), ntohs (cli_addr.sin_port));

--- a/hu/hu_tcp.h
+++ b/hu/hu_tcp.h
@@ -9,6 +9,7 @@ class HUTransportStreamTCP : public HUTransportStream
     socklen_t cli_len = 0;
     struct sockaddr_in  srv_addr = {0};
     socklen_t srv_len = 0;
+    std::string& phoneIpAddress;
 
     int wifi_direct = 0;//0;
     int itcp_deinit ();
@@ -16,7 +17,7 @@ class HUTransportStreamTCP : public HUTransportStream
     int itcp_init();
  public:
     ~HUTransportStreamTCP();
-    HUTransportStreamTCP() {}
+    HUTransportStreamTCP(std::string& phoneIpAddress): phoneIpAddress(phoneIpAddress) {}
     virtual int Start(bool waitForDevice) override;
     virtual int Stop() override;
     virtual int Write(const byte* buf, int len, int tmo) override;

--- a/mazda/headunit.json
+++ b/mazda/headunit.json
@@ -2,5 +2,6 @@
     "launchOnDevice": true,
     "carGPS": true,
     "wifiTransport": false,
+    "phoneIpAddress": "192.168.43.239",
     "reverseGPS": false
 }

--- a/mazda/headunit.json
+++ b/mazda/headunit.json
@@ -2,6 +2,6 @@
     "launchOnDevice": true,
     "carGPS": true,
     "wifiTransport": false,
-    "phoneIpAddress": "192.168.43.239",
+    "phoneIpAddress": "192.168.43.1",
     "reverseGPS": false
 }

--- a/mazda/installer/config/androidauto/data_persist/dev/bin/headunit-wrapper
+++ b/mazda/installer/config/androidauto/data_persist/dev/bin/headunit-wrapper
@@ -31,12 +31,17 @@ start_AAwireless()
 {
     rm -f /tmp/root/headunit.status
     sed -i 's."wifiTransport": false."wifiTransport": true.g' /tmp/root/headunit.json
+    PHONE_IP_ADDRESS=$1
+    shift
+    if [ ! -z $PHONE_IP_ADDRESS ]; then
+        sed -i ﻿"s/\"phoneIpAddress\": \".[^\"]*\"/\"phoneIpAddress\": \"$PHONE_IP_ADDRESS\"/g" /tmp/root/headunit.json
+    fi
     taskset 0xFFFFFFFF "${SCRIPTPATH}/headunit" "$@" > /dev/null 2>&1 &
     sleep 2
     touch /tmp/root/headunit-wireless.status
-   [ $DEBUG -eq 1 ] && echo "=== headunit-wifi ==="
-   [ $DEBUG -eq 1 ] && cat /tmp/root/headunit.json  >> ${LOGPATH}
-   [ $DEBUG -eq 1 ] && echo "===================="
+    [ $DEBUG -eq 1 ] && echo "=== headunit-wifi ==="
+    [ $DEBUG -eq 1 ] && cat /tmp/root/headunit.json  >> ${LOGPATH}
+    [ $DEBUG -eq 1 ] && echo "===================="
 }
 
 rm -f /tmp/root/headunit.status /tmp/root/headunit-wireless.status
@@ -50,7 +55,7 @@ start_headunit
 # loop forever. every 5 seconds,
 while true
 do
- NET_CHECK=`netstat -rn|awk '$2=="192.168.43.1" {print}'|wc -l|awk '{print $1}'`
+ PHONE_IP_ADDRESS=`netstat -rn|awk '$2~/192\.168\.43\.[0-9]{1,3}/ {print $2}'`
 
  if [ -e /tmp/root/usb_connect ]; then
   USBCHECK=1
@@ -60,15 +65,15 @@ do
   [ $DEBUG -eq 1 ] && echo "USB detach" >> ${LOGPATH}
  fi
 
- if [ $NET_CHECK == 1 ] && [ $USBCHECK == 0 ]; then
+ if [ ! -z $PHONE_IP_ADDRESS ] && [ $USBCHECK == 0 ]; then
     [ $DEBUG -eq 1 ] && echo "WLAN Mode" >> ${LOGPATH}
     if [ -e /tmp/root/headunit.status ]; then
         killall -q headunit
     fi
 
     if ! [ -e /tmp/root/headunit-wireless.status ]; then
-        [ $DEBUG -eq 1 ] && echo "Start WIRELESS" >> ${LOGPATH}
-        start_AAwireless
+        [ $DEBUG -eq 1 ] && echo "Start WIRELESS - Phone IP: $PHONE_IP_ADDRESS" >> ${LOGPATH}
+        start_AAwireless $PHONE_IP_ADDRESS
     fi
 
  else

--- a/mazda/main.cpp
+++ b/mazda/main.cpp
@@ -231,7 +231,7 @@ int main (int argc, char *argv[])
             commandCallbacks.eventCallbacks = &callbacks;
 
             //Wait forever for a connection
-            int ret = headunit.hu_aap_start(config::transport_type, true);
+            int ret = headunit.hu_aap_start(config::transport_type, config::phoneIpAddress, true);
             if (ret < 0) {
                 loge("Something bad happened");
                 continue;

--- a/ubuntu/headunit.json
+++ b/ubuntu/headunit.json
@@ -1,5 +1,6 @@
 {
     "launchOnDevice": true,
     "carGPS": true,
-    "wifiTransport":true
+    "wifiTransport":true,
+    "phoneIpAddress": "192.168.43.203"
 }

--- a/ubuntu/headunit.json
+++ b/ubuntu/headunit.json
@@ -2,5 +2,5 @@
     "launchOnDevice": true,
     "carGPS": true,
     "wifiTransport":true,
-    "phoneIpAddress": "192.168.43.203"
+    "phoneIpAddress": "192.168.43.1"
 }

--- a/ubuntu/main.cpp
+++ b/ubuntu/main.cpp
@@ -100,7 +100,7 @@ main(int argc, char *argv[]) {
             HUServer headunit(callbacks);
 
             /* Start AA processing */
-            ret = headunit.hu_aap_start(config::transport_type, true);
+            ret = headunit.hu_aap_start(config::transport_type, config::phoneIpAddress, true);
             if (ret < 0) {
                     printf("Phone is not connected. Connect a supported phone and restart.\n");
                     return 0;


### PR DESCRIPTION
Android [recently made a change which changed the hotspot address from the hardcoded value `192.168.43.1` to a random IP address in the `192.168.43` subnet]( 
https://android.googlesource.com/platform/frameworks/base/+/0f27eed8f666e5ee38cea16b7feb2fd8e43c9b9e).  This means headunit can no longer rely on the hardcoded IP address.  

This PR changes the `headunit-wrapper` script to detect what IP address the Phone HotSpot WiFi is, and writes it to the configuration file as the `phoneIpAddress` field.  The headunit code has also been changed to read this config value and use it as the IP address to connect to.

For backward compatibility, all IP address values have been defaulted to `192.168.43.1`.

Tested on ubuntu and v56 firmware.

_Note: the script didn't make the changes to the configuration file the first few times it ran, but did eventually.  I don't know if I did not overwrite all the correct files in the MZD AIO installer_