### PR TITLE
Vvk/focus

### DIFF
--- a/mazda/outputs.h
+++ b/mazda/outputs.h
@@ -35,6 +35,8 @@ class VideoOutput {
     int touch_fd = -1, kbd_fd = -1, ui_fd = -1;
     void input_thread_func();
     void pass_key_to_mzd(int type, int code, int val);
+    uint32_t pressScanCode;
+    time_t pressedSince;
 
 public:
     VideoOutput(MazdaEventCallbacks* callbacks);


### PR DESCRIPTION
For some reason on my Mazda 3 releasing video focus leads to black screen with only way to get out of is by pressing NAV and then back. So when you by mistake press end call button one time too many you get to that black screen. Not sure if I'm the one with such issue.

At the same time play/pause funcionality never worked in current form in Audible. Pausing first time is fine, but then audio can't be unpaused. I've tried to find some combination to release audio focus on pause and request it back on resume, but couldn'f ind any.

Thus the alternative approach to release audio focus then FAV button is held for longer than 3 seconds and released. And release video focus when BACK button is held for 3 seconds and released.