### PR TITLE
Hud units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mazda/installer/config/androidauto/data_persist/dev/bin/headunit
 *.creator.user
 bin/
 */version\.h
+.vscode

--- a/hu/hu.proto
+++ b/hu/hu.proto
@@ -702,7 +702,12 @@ message BluetoothAuthData
 
 message NAVMessagesStatus
 {
-    optional int32 status = 1;
+    enum STATUS
+    {
+        START = 1;
+        STOP = 2;
+    }
+    optional STATUS status = 1;
 }
 
 message NAVTurnMessage
@@ -747,4 +752,15 @@ message NAVDistanceMessage
 {
     optional int32 distance = 1; //meters
     optional int32 time_until = 2; //seconds
+    optional uint64 display_distance = 3; //distance rounded for display
+    enum DISPLAY_DISTANCE_UNIT
+    {
+        METERS = 1;       // meters * 1000, used when rounded distance < 1000m
+        KILOMETERS10 = 2; // kilometers * 1000, used when rounded distance > 10km, not same as just meters because "km" is displayed on screen
+        KILOMETERS = 3;   // kilometers * 1000, used when rounded distance between 1km and 10km, not same as just meters because "km" is displayed on screen
+        MILES10 = 4;      // miles * 1000, used when rounded distance > 10mi
+        MILES = 5;        // miles * 1000, used when rounded distance between 1mi and 10mi
+        FEET = 6;         // feet * 1000
+    }
+    optional DISPLAY_DISTANCE_UNIT display_distance_unit = 4;
 }

--- a/mazda/hud/hud.cpp
+++ b/mazda/hud/hud.cpp
@@ -26,8 +26,6 @@ static TMCClient *tmc_client = NULL;
 
 NaviData *navi_data = NULL;
 
-
-
 uint8_t turns[][3] = {
   {0,0,0}, //TURN_UNKNOWN
   {NaviTurns::FLAG_LEFT,NaviTurns::FLAG_RIGHT,NaviTurns::FLAG}, //TURN_DEPART
@@ -36,8 +34,8 @@ uint8_t turns[][3] = {
   {NaviTurns::LEFT,NaviTurns::RIGHT,0}, //TURN_TURN
   {NaviTurns::SHARP_LEFT,NaviTurns::SHARP_RIGHT,0}, //TURN_SHARP_TURN
   {NaviTurns::U_TURN_LEFT, NaviTurns::U_TURN_RIGHT,0}, //TURN_U_TURN
-  {NaviTurns::LEFT,NaviTurns::RIGHT,0}, //TURN_ON_RAMP
-  {NaviTurns::LEFT,NaviTurns::RIGHT,0}, //TURN_OFF_RAMP
+  {NaviTurns::LEFT,NaviTurns::RIGHT,NaviTurns::STRAIGHT}, //TURN_ON_RAMP
+  {NaviTurns::LEFT,NaviTurns::RIGHT,NaviTurns::STRAIGHT}, //TURN_OFF_RAMP
   {NaviTurns::FORK_LEFT, NaviTurns::FORK_RIGHT, 0}, //TURN_FORK
   {NaviTurns::MERGE_LEFT, NaviTurns::MERGE_RIGHT, 0}, //TURN_MERGE
   {0,0,0},  //TURN_ROUNDABOUT_ENTER
@@ -68,18 +66,17 @@ void hud_thread_func(std::condition_variable& quitcv, std::mutex& quitmutex, std
     hudmutex.lock();
 
     uint32_t diricon;
-    if(navi_data->turn_event == 13){
-          diricon = roundabout(navi_data->turn_angle);
-    }
-    else{
+    if (navi_data->turn_event == 13) {
+      diricon = roundabout(navi_data->turn_angle);
+    } else {
       int32_t turn_side = navi_data->turn_side-1; //Google starts at 1 for some reason...
       diricon = turns[navi_data->turn_event][turn_side];
     }
 
     ::DBus::Struct< uint32_t, uint16_t, uint8_t, uint16_t, uint8_t, uint8_t > hudDisplayMsg;
     hudDisplayMsg._1 = diricon;
-    hudDisplayMsg._2 = navi_data->distance;
-    hudDisplayMsg._3 = navi_data->distance_unit; //distance unit 1 = meter?
+    hudDisplayMsg._2 = navi_data->distance;// distance;
+    hudDisplayMsg._3 = navi_data->distance_unit;
     hudDisplayMsg._4 = 0; //Speed limit (Not Used)
     hudDisplayMsg._5 = 0; //Speed limit units (Not used)
     hudDisplayMsg._6 = navi_data->previous_msg;
@@ -116,7 +113,7 @@ void hud_start()
 {
   if (hud_client != NULL)
     return;
-
+    
   try
   {
     DBus::Connection service_bus(SERVICE_BUS_ADDRESS, false);

--- a/mazda/hud/hud.h
+++ b/mazda/hud/hud.h
@@ -10,14 +10,22 @@
 
 #include "../dbus/generated_cmu.h"
 
+enum HudDistanceUnit: uint8_t {
+    METERS = 1,
+    MILES = 2,
+    KILOMETERS = 3,
+    YARDS = 4,
+    FEET = 5
+};
+
 struct NaviData {
   std::string event_name;
   int32_t turn_side;
   int32_t turn_event;
   int32_t turn_number;
   int32_t turn_angle;
-  int32_t distance;
-  uint8_t distance_unit;
+  int32_t distance; // distance * 10, encoded like that to store one digit after decimal dot in int type
+  HudDistanceUnit distance_unit; 
   int32_t time_until;
   uint8_t previous_msg;
   uint8_t changed;


### PR DESCRIPTION
- Tracking HandleNaviStatus for stop signal to clear HUD when navigation finishes or canceled.
- Displaying Straight icon for merge without direction. Seems fitting and better than not not showing anything.
- Displaying HUD distance in units reported by AA.