### PR TITLE
Possible solution for left-hand roundabouts

### DIFF
--- a/mazda/hud/hud.cpp
+++ b/mazda/hud/hud.cpp
@@ -49,9 +49,9 @@ uint8_t turns[][3] = {
   {NaviTurns::DESTINATION_LEFT, NaviTurns::DESTINATION_RIGHT, NaviTurns::DESTINATION} //TURN_DESTINATION
 };
 
-uint8_t roundabout(int32_t degrees){
+uint8_t roundabout(int32_t degrees, int32_t side){
   uint8_t nearest = (degrees + 15) / 30;
-  uint8_t offset = 37; //+49 for Left hand drive?
+  uint8_t offset = side == 0 ? 49 : 37;
   return(nearest + offset);
 }
 
@@ -67,9 +67,9 @@ void hud_thread_func(std::condition_variable& quitcv, std::mutex& quitmutex, std
 
     uint32_t diricon;
     if (navi_data->turn_event == 13) {
-      diricon = roundabout(navi_data->turn_angle);
+      diricon = roundabout(navi_data->turn_angle, navi_data->turn_side - 1);
     } else {
-      int32_t turn_side = navi_data->turn_side-1; //Google starts at 1 for some reason...
+      int32_t turn_side = navi_data->turn_side - 1; //Google starts at 1 for some reason...
       diricon = turns[navi_data->turn_event][turn_side];
     }
 


### PR DESCRIPTION
I can't test it since I do not have access to left-hand roads. For right-hand driving phone sends turn_side=2 and positive angle. At the same time for non roundabouts phone sends angle -1, so I assume that it will not send negative angles in general. Thus it is possible that for left-hand roundabouts phone will send positive angle with turn_side=1 to indicate left turn.

Can we put this into beta and have someone test it? There was at least one person on mazdarevolution complaining about that.