### PR TITLE
Support for interleaved channel data

### DIFF
--- a/hu/hu_aap.cpp
+++ b/hu/hu_aap.cpp
@@ -144,12 +144,12 @@
   {
     const int messageSize = message.ByteSize();
     const int requiredSize = messageSize + 2;
-    if (temp_assembly_buffer.size() < requiredSize)
+    if (temp_assembly_buffer->size() < requiredSize)
     {
-      temp_assembly_buffer.resize(requiredSize);
+      temp_assembly_buffer->resize(requiredSize);
     }
 
-    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer.data());
+    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer->data());
     *destMessageCode++ = htobe16(messageCode);
 
     if (!message.SerializeToArray(destMessageCode, messageSize))
@@ -159,20 +159,20 @@
     }
 
     logd ("Send %s on channel %i %s", message.GetTypeName().c_str(), chan, chan_get(chan));
-    //hex_dump("PB:", 80, temp_assembly_buffer.data(), requiredSize);
-    return hu_aap_enc_send(retry, chan, temp_assembly_buffer.data(), requiredSize, overrideTimeout);
+    //hex_dump("PB:", 80, temp_assembly_buffer->data(), requiredSize);
+    return hu_aap_enc_send(retry, chan, temp_assembly_buffer->data(), requiredSize, overrideTimeout);
 
   }
 
   int HUServer::hu_aap_enc_send_media_packet(int retry, int chan, uint16_t messageCode, uint64_t timeStamp, const byte* buffer, int bufferLen, int overrideTimeout)
   {
     const int requiredSize = bufferLen + 2 + 8;
-    if (temp_assembly_buffer.size() < requiredSize)
+    if (temp_assembly_buffer->size() < requiredSize)
     {
-      temp_assembly_buffer.resize(requiredSize);
+      temp_assembly_buffer->resize(requiredSize);
     }
 
-    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer.data());
+    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer->data());
     *destMessageCode++ = htobe16(messageCode);
 
     uint64_t* destTimestamp = reinterpret_cast<uint64_t*>(destMessageCode);
@@ -181,8 +181,8 @@
     memcpy(destTimestamp, buffer, bufferLen);
 
     //logd ("Send %s on channel %i %s", message.GetTypeName().c_str(), chan, chan_get(chan));
-    //hex_dump("PB:", 80, temp_assembly_buffer.data(), requiredSize);
-    return hu_aap_enc_send(retry, chan, temp_assembly_buffer.data(), requiredSize, overrideTimeout);
+    //hex_dump("PB:", 80, temp_assembly_buffer->data(), requiredSize);
+    return hu_aap_enc_send(retry, chan, temp_assembly_buffer->data(), requiredSize, overrideTimeout);
   }
 
   int HUServer::hu_aap_enc_send (int retry,int chan, byte * buf, int len, int overrideTimeout) {                 // Encrypt data and send: type,...
@@ -336,31 +336,31 @@
   int HUServer::hu_aap_unenc_send_blob(int retry, int chan, uint16_t messageCode, const byte* buffer, int bufferLen, int overrideTimeout)
   {
     const int requiredSize = bufferLen + 2;
-    if (temp_assembly_buffer.size() < requiredSize)
+    if (temp_assembly_buffer->size() < requiredSize)
     {
-      temp_assembly_buffer.resize(requiredSize);
+      temp_assembly_buffer->resize(requiredSize);
     }
 
-    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer.data());
+    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer->data());
     *destMessageCode++ = htobe16(messageCode);
 
      memcpy(destMessageCode, buffer, bufferLen);
 
     //logd ("Send %s on channel %i %s", message.GetTypeName().c_str(), chan, chan_get(chan));
-    //hex_dump("PB:", 80, temp_assembly_buffer.data(), requiredSize);
-    return hu_aap_unenc_send(retry, chan, temp_assembly_buffer.data(), requiredSize, overrideTimeout);
+    //hex_dump("PB:", 80, temp_assembly_buffer->data(), requiredSize);
+    return hu_aap_unenc_send(retry, chan, temp_assembly_buffer->data(), requiredSize, overrideTimeout);
   }
 
   int HUServer::hu_aap_unenc_send_message(int retry, int chan, uint16_t messageCode, const google::protobuf::MessageLite& message, int overrideTimeout)
   {
     const int messageSize = message.ByteSize();
     const int requiredSize = messageSize + 2;
-    if (temp_assembly_buffer.size() < requiredSize)
+    if (temp_assembly_buffer->size() < requiredSize)
     {
-      temp_assembly_buffer.resize(requiredSize);
+      temp_assembly_buffer->resize(requiredSize);
     }
 
-    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer.data());
+    uint16_t* destMessageCode = reinterpret_cast<uint16_t*>(temp_assembly_buffer->data());
     *destMessageCode++ = htobe16(messageCode);
 
     if (!message.SerializeToArray(destMessageCode, messageSize))
@@ -370,8 +370,8 @@
     }
 
     logd ("Send %s on channel %i %s", message.GetTypeName().c_str(), chan, chan_get(chan));
-    //hex_dump("PB:", 80, temp_assembly_buffer.data(), requiredSize);
-    return hu_aap_unenc_send(retry, chan, temp_assembly_buffer.data(), requiredSize, overrideTimeout);
+    //hex_dump("PB:", 80, temp_assembly_buffer->data(), requiredSize);
+    return hu_aap_unenc_send(retry, chan, temp_assembly_buffer->data(), requiredSize, overrideTimeout);
   }
 
 
@@ -1377,9 +1377,6 @@
     int min_size_hdr = 4;
     int have_len = 0;                                                   // Length remaining to process for all sub-packets plus 4/8 byte headers
 
-
-    temp_assembly_buffer.clear();
-
     bool has_last = false;
     bool has_first = false;
     int chan = -1;
@@ -1403,10 +1400,14 @@
       int cur_chan = (int) enc_buf [0];                                         // Channel
       if (cur_chan != chan && chan >= 0)
       {
-          loge ("Interleaved channels");
-          return (-1);
+          logd ("Interleaved channels, preserving incomplete packet for chan %s", chan_get (chan));
+          channel_assembly_buffers[chan] = temp_assembly_buffer;
+          temp_assembly_buffer = NULL;
+          has_first = has_last = false;
+          //return (-1);
       }
       chan = cur_chan;
+
       int flags = enc_buf [1];                                              // Flags
       int frame_len = be16toh(*((uint16_t*)&enc_buf[2]));
 
@@ -1440,11 +1441,28 @@
         remaining_bytes_in_frame -= got_bytes;
       }
 
-      if (!has_first && !(flags & HU_FRAME_FIRST_FRAME))
+      auto buffer = channel_assembly_buffers.find(chan);
+      if (buffer != channel_assembly_buffers.end()) // Have old buffer with incomplete data for channel
       {
-          loge ("No HU_FRAME_FIRST_FRAME");
-          return (-1);
+        logd ("Found existing buffer for chan %s", chan_get (chan));
+        temp_assembly_buffer = buffer->second;
       }
+      else if (temp_assembly_buffer == NULL) // Old buffer had incomplete data and was preserved, need to create new one
+      {
+        logd ("Created new buffer for chan %s", chan_get (chan));
+        temp_assembly_buffer = new std::vector<uint8_t>();
+      }
+
+      if (flags & HU_FRAME_FIRST_FRAME)
+      {
+        temp_assembly_buffer->clear(); // It's the first frame and old data may still be there, so clear
+      }
+      else if (!has_first && temp_assembly_buffer->size() == 0) // No first frame yet and buffer is empty
+      {
+        loge ("No HU_FRAME_FIRST_FRAME, and no incomplete buffer for chan %s", chan_get (chan));
+        return (-1);
+      }
+
       has_first = true;
       has_last = (flags & HU_FRAME_LAST_FRAME) != 0;
 
@@ -1452,18 +1470,18 @@
       {
         uint32_t total_size = be32toh(*((uint32_t*)&enc_buf[4]));
         logd("First only, total len %u", total_size);
-        temp_assembly_buffer.reserve(total_size);
+        temp_assembly_buffer->reserve(total_size);
       }
       else
       {
-        temp_assembly_buffer.reserve(frame_len);
+        temp_assembly_buffer->reserve(frame_len);
       }
 
 
       if (flags & HU_FRAME_ENCRYPTED)
       {
-          size_t cur_vec = temp_assembly_buffer.size();
-          temp_assembly_buffer.resize(cur_vec + frame_len); //just incase
+          size_t cur_vec = temp_assembly_buffer->size();
+          temp_assembly_buffer->resize(cur_vec + frame_len); //just incase
 
           int bytes_written = BIO_write (hu_ssl_rm_bio, &enc_buf[header_size], frame_len);           // Write encrypted to SSL input BIO
           if (bytes_written <= 0) {
@@ -1475,7 +1493,7 @@
           else if (ena_log_verbo)
             logd ("BIO_write() len: %d  bytes_written: %d  chan: %d %s", frame_len, bytes_written, chan, chan_get (chan));
 
-          int bytes_read = SSL_read (hu_ssl_ssl, &temp_assembly_buffer[cur_vec], frame_len);   // Read decrypted to decrypted rx buf
+          int bytes_read = SSL_read (hu_ssl_ssl, &(*temp_assembly_buffer)[cur_vec], frame_len);   // Read decrypted to decrypted rx buf
           if (bytes_read <= 0 || bytes_read > frame_len) {
             loge ("SSL_read() bytes_read: %d  errno: %d", bytes_read, errno);
             hu_ssl_ret_log (bytes_read);
@@ -1484,20 +1502,20 @@
           if (ena_log_verbo)
             logd ("SSL_read() bytes_read: %d", bytes_read);
 
-          temp_assembly_buffer.resize(cur_vec + bytes_read);
+          temp_assembly_buffer->resize(cur_vec + bytes_read);
       }
       else
       {
-          temp_assembly_buffer.insert(temp_assembly_buffer.end(), &enc_buf[header_size], &enc_buf[frame_len+header_size]);
+          temp_assembly_buffer->insert(temp_assembly_buffer->end(), &enc_buf[header_size], &enc_buf[frame_len+header_size]);
       }
     }
 
-    const int buf_len = temp_assembly_buffer.size();
+    const int buf_len = temp_assembly_buffer->size();
     if (buf_len >= 2)
     {
-      uint16_t msg_type = be16toh(*reinterpret_cast<uint16_t*>(temp_assembly_buffer.data()));
+      uint16_t msg_type = be16toh(*reinterpret_cast<uint16_t*>(temp_assembly_buffer->data()));
 
-      ret = iaap_msg_process (chan, msg_type, &temp_assembly_buffer[2], buf_len - 2);          // Decrypt & Process 1 received encrypted message
+      ret = iaap_msg_process (chan, msg_type, &(*temp_assembly_buffer)[2], buf_len - 2);          // Decrypt & Process 1 received encrypted message
       if (ret < 0 && iaap_state != hu_STATE_STOPPED) {                                                    // If error...
         loge ("Error iaap_msg_process() ret: %d  ", ret);
         return (ret);

--- a/hu/hu_aap.h
+++ b/hu/hu_aap.h
@@ -201,7 +201,8 @@ protected:
   HU_STATE iaap_state = hu_STATE_INITIAL;
   int iaap_tra_recv_tmo = 150;//100;//1;//10;//100;//250;//100;//250;//100;//25; // 10 doesn't work ? 100 does
   int iaap_tra_send_tmo = 500;//2;//25;//250;//500;//100;//500;//250;
-  std::vector<uint8_t> temp_assembly_buffer;
+  std::vector<uint8_t>* temp_assembly_buffer = new std::vector<uint8_t>();
+  std::map<int, std::vector<uint8_t>*> channel_assembly_buffers;
   byte enc_buf[MAX_FRAME_SIZE] = {0};
   int32_t channel_session_id[AA_CH_MAX] = {0};
 

--- a/hu/hu_uti.cpp
+++ b/hu/hu_uti.cpp
@@ -44,9 +44,9 @@ int gen_server_poll_func (int poll_ms);
 
   // Log stuff:
 
-int ena_log_extra   = 1;//1;//0;
-int ena_log_verbo   = 1;//1;
-int ena_log_debug   = 1;
+int ena_log_extra   = 0;
+int ena_log_verbo   = 0;
+int ena_log_debug   = 0;
 int ena_log_warni   = 1;
 int ena_log_error   = 1;
 
@@ -100,7 +100,9 @@ int hu_log (int prio, const char * tag, const char * func, const char * fmt, ...
   int len = vsnprintf (log_line, sizeof (log_line), fmt, aq);
 
   //Time doesn't work on CMU anyway, always says 1970
-  printf ("%s: %s: %s : %s\n", prio_get (prio), tag, func, log_line);
+  time_t timestamp;
+  time(&timestamp);
+  printf ("%d %s: %s: %s : %s\n", timestamp, prio_get (prio), tag, func, log_line);
 
   va_end(aq);
 #endif

--- a/hu/hu_uti.cpp
+++ b/hu/hu_uti.cpp
@@ -44,9 +44,9 @@ int gen_server_poll_func (int poll_ms);
 
   // Log stuff:
 
-int ena_log_extra   = 0;//1;//0;
-int ena_log_verbo   = 0;//1;
-int ena_log_debug   = 0;
+int ena_log_extra   = 1;//1;//0;
+int ena_log_verbo   = 1;//1;
+int ena_log_debug   = 1;
 int ena_log_warni   = 1;
 int ena_log_error   = 1;
 


### PR DESCRIPTION
Recently AA (5.0.500224-release) on my phone (Pixel 2XL) started sending video data interleaved with other channels. About 900 bytes spill over into another data frame. Current implementation in headunit can't handle that and exits. This may happen once a minute or every second, most likely depends on complexity of screen information since that would increase video bitrate.

Approach in PR does not allocate separate buffer for each channel upfront - don't wan't to waste memory for anyone who does not face the issue, instead if interleaved data is detected and there is some data in temp assembly buffer it's preserved in it's current state and new buffer is allocated for every other channel but current one. In theory it's possible that eventually every channel still ends up with a separate buffer, but i find it doubtful since video is the most demanding one. Also I've seen this happen only to video channel.