### PR TITLE
Change set_head_unit_name to mazda to get mazda icon for exit button

### DIFF
--- a/hu/hu_aap.cpp
+++ b/hu/hu_aap.cpp
@@ -397,7 +397,7 @@
       logd ("Service Discovery Request: %s", request.phone_name().c_str());                               // S 0 CTR b src: HU  lft:   113  msg_type:     6 Service Discovery Response    S 0 CTR b 00000000 0a 08 08 01 12 04 0a 02 08 0b 0a 13 08 02 1a 0f
 
     HU::ServiceDiscoveryResponse carInfo;
-    carInfo.set_head_unit_name("Mazda Connect");
+    carInfo.set_head_unit_name("mazda");
     carInfo.set_car_model("Mazda");
     carInfo.set_car_year("2016");
     carInfo.set_car_serial("0001");


### PR DESCRIPTION
Change the exit icon from general one to mazda.
Before: 
![image](https://user-images.githubusercontent.com/6975928/74924442-c6b1cc80-53d2-11ea-8224-848d3a871357.png)
After:
![image](https://user-images.githubusercontent.com/6975928/74924394-ab46c180-53d2-11ea-8b1e-1602614450ce.png)
