### PR TITLE
Changing DPI to 132

### DIFF
--- a/hu/hu_aap.cpp
+++ b/hu/hu_aap.cpp
@@ -473,7 +473,7 @@
       videoConfig->set_frame_rate(HU::ChannelDescriptor::OutputStreamChannel::VideoConfig::VIDEO_FPS_30);
       videoConfig->set_margin_width(0);
       videoConfig->set_margin_height(0);
-      videoConfig->set_dpi(140);
+      videoConfig->set_dpi(132);
       inner->set_available_while_in_call(true);
 
       callbacks.CustomizeOutputChannel(AA_CH_VID, *inner);


### PR DESCRIPTION
Being 800px horizontally over 6 inches of screen it's technically 133.333, so using more round value of 132. This makes UI a bit tighter and nicer to look as fonts become a bit less bold.