### PR TITLE
fix hud display will be clear sometimes.

### DIFF
--- a/mazda/callbacks.cpp
+++ b/mazda/callbacks.cpp
@@ -758,11 +758,19 @@ void MazdaEventCallbacks::HandleNaviTurnDistance(IHUConnectionThreadInterface& s
     navi_data->distance_unit = now_unit;
     navi_data->distance = now_distance;
     navi_data->changed = 1;
+    navi_data->previous_msg = navi_data->previous_msg+1;
+    if (navi_data->previous_msg == 8) {
+      navi_data->previous_msg = 1;
+    }
   }
 
   if (navi_data->time_until != request.time_until()) {
     navi_data->time_until = request.time_until();
     navi_data->changed = 1;
+    navi_data->previous_msg = navi_data->previous_msg+1;
+    if (navi_data->previous_msg == 8) {
+      navi_data->previous_msg = 1;
+    }
   }
 
   hudmutex.unlock();

--- a/mazda/hud/hud.cpp
+++ b/mazda/hud/hud.cpp
@@ -35,7 +35,7 @@ uint8_t turns[][3] = {
   {NaviTurns::SHARP_LEFT,NaviTurns::SHARP_RIGHT,0}, //TURN_SHARP_TURN
   {NaviTurns::U_TURN_LEFT, NaviTurns::U_TURN_RIGHT,0}, //TURN_U_TURN
   {NaviTurns::LEFT,NaviTurns::RIGHT,NaviTurns::STRAIGHT}, //TURN_ON_RAMP
-  {NaviTurns::LEFT,NaviTurns::RIGHT,NaviTurns::STRAIGHT}, //TURN_OFF_RAMP
+  {NaviTurns::OFF_RAMP_LEFT,NaviTurns::OFF_RAMP_RIGHT,NaviTurns::STRAIGHT}, //TURN_OFF_RAMP
   {NaviTurns::FORK_LEFT, NaviTurns::FORK_RIGHT, 0}, //TURN_FORK
   {NaviTurns::MERGE_LEFT, NaviTurns::MERGE_RIGHT, 0}, //TURN_MERGE
   {0,0,0},  //TURN_ROUNDABOUT_ENTER

--- a/mazda/hud/hud.h
+++ b/mazda/hud/hud.h
@@ -50,7 +50,9 @@ enum NaviTurns: uint32_t {
   FORK_LEFT = 15,
   FORK_RIGHT = 14,
   MERGE_LEFT = 16,
-  MERGE_RIGHT = 17
+  MERGE_RIGHT = 17,
+  OFF_RAMP_LEFT = 7,
+  OFF_RAMP_RIGHT = 30
 };
 
 void hud_start();


### PR DESCRIPTION
fix hud display will be clear sometimes.
the number of message must be increase. 
In offical system it will not need if only distance change. But it do not work here.
So we increase it everytime. The distance information now will be always display on hud